### PR TITLE
Update config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -58761,6 +58761,10 @@
     "worldcoin.si",
     "blurcrypto.io",
     "appgmx.io",
-    "aavev3lp.com"
+    "aavev3lp.com",
+    "boringpunk.legal",
+    "meesredirect.xyz",
+    "matrixmeta.land",
+    "matrixmeta.world"
   ]
 }


### PR DESCRIPTION
Added several domains being used for Discord verification bot scams, token stealing bookmark/java, and keystealers.

boringpunk.legal
meesredirect.xyz
matrixmeta.land
matrixmeta.world